### PR TITLE
Move probability consistency computation

### DIFF
--- a/StochasticBarrierFunctions/src/constant_barrier.jl
+++ b/StochasticBarrierFunctions/src/constant_barrier.jl
@@ -88,13 +88,6 @@ function expectation_constraint!(model, B, Xⱼ, Bⱼ, βⱼ)
     """
 
     P̅, P̅ᵤ = prob_upper(Xⱼ), prob_unsafe_upper(Xⱼ)
-    P̲, P̲ᵤ = prob_lower(Xⱼ), prob_unsafe_lower(Xⱼ)
-
-    # Trim over-conservative max probabilities in q' space
-    # FIXME: Move this logic to RegionWithProbabilities - it works for all methods.
-    sum_lower = 1 - sum(P̲) - P̲ᵤ
-    P̅ = min.(P̅, sum_lower .- P̲)
-    P̅ᵤ = min(P̅ᵤ, sum_lower - P̲ᵤ)
 
     # Constraint martingale
     @constraint(model, dot(B, P̅) + P̅ᵤ <= Bⱼ + βⱼ)


### PR DESCRIPTION
Close #53 

- Move computation of transition probability consistency/conservativity trim to the transition probability computation, such that it applies to all methods rather than just the upper bound and iterative approaches.
- Refactor the transition kernel closures out into structs that represent `T(X | x)` and `log(T(X | x))` such that the compiler does not need to recompile the closures every iteration, and that it can optimize for specific data types.