### PR TITLE
Switch to Nesterov momentum

### DIFF
--- a/StochasticBarrierFunctions/src/barrier.jl
+++ b/StochasticBarrierFunctions/src/barrier.jl
@@ -57,7 +57,10 @@ Base.@kwdef struct IterativeUpperBoundAlgorithm <: ConstantBarrierAlgorithm
 end
 
 Base.@kwdef struct GradientDescentAlgorithm <: ConstantBarrierAlgorithm
-    num_iterations = 10000
+    num_iterations = 1000
+    initial_lr = 1e-2
+    decay = 0.995
+    momentum = 0.99
 end
 
 Base.@kwdef struct SumOfSquaresAlgorithm <: SOSBarrierAlgorithm

--- a/StochasticBarrierFunctions/src/gradient_descent_barrier.jl
+++ b/StochasticBarrierFunctions/src/gradient_descent_barrier.jl
@@ -10,84 +10,101 @@ function synthesize_barrier(alg::GradientDescentAlgorithm, regions::Vector{<:Reg
 
     initial_indices = findall(X -> !isdisjoint(initial_region, region(X)), regions)
     unsafe_indices = findall(X -> !isdisjoint(obstacle_region, region(X)), regions)
-    push!(unsafe_indices, n + 1)
 
-    B = fill(0.5, n + 1)
-    B_init = @view(B[initial_indices])
-    B_unsafe = @view(B[unsafe_indices])
-    B_regions = @view(B[1:end - 1])
-    dB = similar(B)
+    ws = GradientDescentWorkspace(n, initial_indices, unsafe_indices)
+    project!(ws)
 
-    B_init .= 0
-    B_unsafe .= 1
+    decay = Exp(λ = alg.initial_lr, γ = alg.decay)
+    optim = Optimisers.Nesterov(alg.initial_lr, alg.momentum)
 
-    decay = Exp(λ = 1e-1, γ = 0.9995)
-    optim = Optimisers.Adam(1e-1, (8e-1, 9.99e-1))
-
-    state = Optimisers.setup(optim, B)
+    state = Optimisers.setup(optim, ws.B)
 
     p = [zero(region.gap) for region in regions]
     q = collect(UnitRange{Int64}(1, n + 1))
-    βⱼ = zeros(n)
 
     prev_q = copy(q)
 
-    for t in 0:10000
-        sortperm!(q, B, rev=true)
-
-        if q != prev_q
-            copyto!(prev_q, q)
-            ivi_prob!.(p, regions, tuple(q))
-        end
-
-        βⱼ .= dot.(tuple(B), p)
-        βⱼ .-= B_regions
-        j = argmax(βⱼ)
-
-        copyto!(dB, B)
-        dB .-= decay(t) .* p[j]
-        dB[j] += decay(t) * 1
-        clamp!(dB, 0, 1)
-        dB .*= -1
-        dB .+= B
-        dB ./= decay(t)
-
-        Optimisers.adjust!(state, decay(t))
-        state, B = Optimisers.update!(state, B, dB)
-
-        # Projection onto [0, 1]^n x {1}
-        clamp!(B, 0, 1)
-        B_init .= 0
-        B_unsafe .= 1
+    for k in 0:alg.num_iterations
+        state = gradient_descent_barrier_iteration!(ws, state, regions, prev_q, q, p, decay(k))
     end
 
-    η = maximum(B_init)
+    η = maximum(ws.B_init)
 
-    sortperm!(q, B, rev=true)
+    sortperm!(q, ws.B, rev=true)
     ivi_prob!.(p, regions, tuple(q))
-    βⱼ .= dot.(tuple(B), p)
-    βⱼ .-= B_regions
-    clamp!(βⱼ, 0, Inf)
+
+    βⱼ = beta(ws, p)
 
     @info "Solution Gradient Descent" η β=maximum(βⱼ) Pₛ=1 - (η + maximum(βⱼ) * time_horizon) iterations=alg.num_iterations
 
     Xs = map(region, regions)
-    return ConstantBarrier(Xs, B_regions), βⱼ
+    return ConstantBarrier(Xs, ws.B_regions), βⱼ
 end
 
-# This function bould be useful as a template for parallelizing onto the gpu.
-function β_direct(B, X::RegionWithProbabilities, p::AbstractVector{<:Int})    
-    remaining = 1 - X.sum_lower
-    s = dot(B, X.lower)
-    
-    for i in p
-        @inbounds s += min(remaining, X.gap[i]) * B[i] 
-        @inbounds remaining -= X.gap[i]
+mutable struct GradientDescentWorkspace{T, BT<:AbstractVector{T}, VT<:AbstractVector{T}, RT<:AbstractVector{T}}
+    B::BT
+    dB::BT
+    β::BT  # This only functions as a cache. It should never be accessed directly. 
 
-        if remaining < 0
-            break
-        end
+    B_init::VT
+    B_unsafe::VT
+    B_regions::RT
+end
+
+function GradientDescentWorkspace(n::Integer, initial_indices::AbstractVector, unsafe_indices::AbstractVector)
+    B = fill(0.5, n + 1)
+    dB = similar(B)
+    β = zeros(n)
+
+    # The sinking state is considered unsafe
+    push!(unsafe_indices, n + 1)
+
+    B_init = @view(B[initial_indices])
+    B_unsafe = @view(B[unsafe_indices])
+    B_regions = @view(B[1:end - 1])
+
+    return GradientDescentWorkspace(B, dB, β, B_init, B_unsafe, B_regions)
+end
+
+function project!(ws::GradientDescentWorkspace)
+    # Projection onto [0, 1]^n x {1}
+    clamp!(ws.B, 0, 1)
+    ws.B_init .= 0
+    ws.B_unsafe .= 1
+end
+
+function beta(ws::GradientDescentWorkspace{T}, p) where {T}
+    ws.β .= dot.(tuple(ws.B), p)
+    ws.β .-= ws.B_regions
+    clamp!(ws.β, T(0), T(Inf))
+
+    return ws.β
+end
+
+function gradient!(ws::GradientDescentWorkspace, p)
+    βⱼ = beta(ws, p)
+    j = argmax(βⱼ)
+
+    ws.dB .= p[j]
+    ws.dB[j] -= 1
+
+    return ws.dB
+end
+
+function gradient_descent_barrier_iteration!(ws, state, regions, prev_q, q, p, lr)
+    sortperm!(q, ws.B, rev=true)
+
+    if q != prev_q
+        copyto!(prev_q, q)
+        ivi_prob!.(p, regions, tuple(q))
     end
 
-    return s
+    gradient!(ws, p)
+
+    Optimisers.adjust!(state, lr)
+    state, ws.B = Optimisers.update!(state, ws.B, ws.dB)
+
+    project!(ws)
+
+    return state
 end


### PR DESCRIPTION
Switching to Nesterov momentum with high rho (typical is 0.9, we use 0.99) results in convergence to the optimal solution with 1/10th the amount of iterations. This was done as part of experimentation with log-sum-exp, which turned out to be negative. 

I also refactored GD quite a bit to allow the compiler to make better use of data types, meaning that it is even faster. 